### PR TITLE
Add support for GNOME 42

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,5 +9,5 @@
     "42"
   ],
   "url": "https://github.com/win0err/gnome-runcat",
-  "version": 17
+  "version": 18
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "3.38",
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/win0err/gnome-runcat",
   "version": 17

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -18,6 +18,7 @@ const RuncatSettingsWidget = GObject.registerClass(
             if (isGtk4) {
                 super._init({
                     hscrollbar_policy: Gtk.PolicyType.NEVER,
+                    vexpand: true,
                 });
             } else {
                 super._init({


### PR DESCRIPTION
This pull request fixes the bug with the extension settings dialog from #26 on GNOME 42 and marks the extension as supporting GNOME 42 in metadata.json.
![runcat-fixed](https://user-images.githubusercontent.com/7506308/159184321-2cc22872-fe89-4f01-bc99-30564d61c52a.png)