### PR TITLE
Allow installation on GNOME 43

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -10,5 +10,5 @@
     "43"
   ],
   "url": "https://github.com/win0err/gnome-runcat",
-  "version": 18
+  "version": 19
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,7 +6,8 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/win0err/gnome-runcat",
   "version": 18


### PR DESCRIPTION
This patch adds "43" to the allowed shell versions. RunCat works on GNOME 43 as-is without any other changes.