### PR TITLE
Maintain consistent widget width

### DIFF
--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-runcat-extension 21\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-05 02:43+0300\n"
+"POT-Creation-Date: 2023-02-07 10:04+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/panelMenuButton.js:95
+#: src/panelMenuButton.js:99
 msgid "Open System Monitor"
 msgstr ""
 
-#: src/panelMenuButton.js:99
+#: src/panelMenuButton.js:103
 msgid "Settings"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-runcat-extension 20\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-05 02:43+0300\n"
+"POT-Creation-Date: 2023-02-07 10:03+0800\n"
 "PO-Revision-Date: 2022-09-30 19:16+0300\n"
 "Last-Translator: Sergei Kolesnikov <sergei@kolesnikov.se>\n"
 "Language-Team: Russian\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: src/panelMenuButton.js:95
+#: src/panelMenuButton.js:99
 msgid "Open System Monitor"
 msgstr "Открыть Системный монитор"
 
-#: src/panelMenuButton.js:99
+#: src/panelMenuButton.js:103
 msgid "Settings"
 msgstr "Настройки"
 

--- a/src/panelMenuButton.js
+++ b/src/panelMenuButton.js
@@ -85,8 +85,9 @@ var PanelMenuButton = GObject.registerClass(
                 labelBox.hide();
             }
 
-            if (itemsVisibility.percentage && itemsVisibility.percentage)
-                labelBox.set_property('style',"padding-left: 0px;")
+            if (itemsVisibility.percentage && itemsVisibility.percentage){
+                labelBox.set_style("padding-left: 0px;");
+            }
 
             const box = this.ui.builder.get_object('box');
             box.add_child(icon);

--- a/src/panelMenuButton.js
+++ b/src/panelMenuButton.js
@@ -85,10 +85,8 @@ var PanelMenuButton = GObject.registerClass(
                 labelBox.hide();
             }
 
-            if (itemsVisibility.percentage && itemsVisibility.percentage) {
-                //icon.set_property('style',"padding-right: 0px;");
-                labelBox.set_property('style',"padding-left: 0px;");
-            }
+            if (itemsVisibility.percentage && itemsVisibility.percentage)
+                labelBox.set_property('style',"padding-left: 0px;")
 
             const box = this.ui.builder.get_object('box');
             box.add_child(icon);

--- a/src/panelMenuButton.js
+++ b/src/panelMenuButton.js
@@ -85,6 +85,11 @@ var PanelMenuButton = GObject.registerClass(
                 labelBox.hide();
             }
 
+            if (itemsVisibility.percentage && itemsVisibility.percentage) {
+                //icon.set_property('style',"padding-right: 0px;");
+                labelBox.set_property('style',"padding-left: 0px;");
+            }
+
             const box = this.ui.builder.get_object('box');
             box.add_child(icon);
             box.add_child(labelBox);

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -6,4 +6,7 @@
 .runcat-menu__label {
     font-size: .9em;
     line-height: 1;
+    width: 2em;
+    padding-right: 0.5em;
+    text-align: right;
 }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -7,6 +7,6 @@
     font-size: .9em;
     line-height: 1;
     width: 2.4em;
-    padding-right: 5px;
+    padding-right: 0.2em;
     text-align: right;
 }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -1,12 +1,12 @@
 .runcat-menu__icon {
-    padding: 0 .5em 0 0;
+    padding: 0 .2em 0 0;
     icon-size: 2em;
 }
 
 .runcat-menu__label {
     font-size: .9em;
     line-height: 1;
-    width: 2.1em;
-    padding-right: 0.5em;
+    width: 2.4em;
+    padding-right: 5px;
     text-align: right;
 }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -6,7 +6,7 @@
 .runcat-menu__label {
     font-size: .9em;
     line-height: 1;
-    width: 2em;
+    width: 2.1em;
     padding-right: 0.5em;
     text-align: right;
 }


### PR DESCRIPTION
Hello,

As mentioned on a previously cancelled PR, the widget changes width when the % drops below 10, making the panel icons around it move around. Rather than manually adding some spaces to the label value as I did before, I tried to implement a neater CSS based solution here to set a fixed width, combined with right alignment for the text and some padding to keep the text away from the adjacent icons.

Please have a look and let me know what you think. I'm not really an expert with setting dimensions with the various notations between numbers, em or pixel values but I figures that the em ratio would be the more appropriate to make sure it's proportional to the font size. 2.0em was leading to the width being too short with font scaling >1.1. I tested a width of 2.1em and had no issue even if I tripled the font size. 

Btw, I also test with % only or icon only and they also look fine.

before:
![image](https://user-images.githubusercontent.com/56710655/213435883-c1b5a644-78e1-42ec-a859-49193033ac13.png)
![image](https://user-images.githubusercontent.com/56710655/213435980-afe2beab-3b87-4ae6-81d8-a1dba9d6de58.png)

after:
![image](https://user-images.githubusercontent.com/56710655/213435390-4d0a49fb-bf55-4c38-9167-f7b2c1934955.png)
![image](https://user-images.githubusercontent.com/56710655/213435568-5673242c-06db-4e7b-8dea-2bea230c52da.png)