### PR TITLE
Add "reverse speed" setting

### DIFF
--- a/po/messages.pot
+++ b/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-runcat-extension \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-12 13:59+0100\n"
+"POT-Creation-Date: 2024-01-15 10:39+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/indicator.js:170
+#: src/indicator.js:169
 msgid "Open System Monitor"
 msgstr ""
 
-#: src/indicator.js:174
+#: src/indicator.js:173
 msgid "Settings"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "RunCat Settings"
 msgstr ""
 
-#: src/prefs.js:116
+#: src/prefs.js:126
 msgid "Version"
 msgstr ""
 
@@ -62,7 +62,7 @@ msgid "Character only"
 msgstr ""
 
 #: src/resources/ui/preferences.ui:49
-msgid "Reverse speed"
+msgid "Invert running speed"
 msgstr ""
 
 #: src/resources/ui/preferences.ui:63

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: gnome-runcat-extension 26\n"
+"Project-Id-Version: gnome-runcat-extension \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-04 10:53+0300\n"
+"POT-Creation-Date: 2024-01-12 13:59+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/indicator.js:161
+#: src/indicator.js:170
 msgid "Open System Monitor"
 msgstr ""
 
-#: src/indicator.js:165
+#: src/indicator.js:174
 msgid "Settings"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "RunCat Settings"
 msgstr ""
 
-#: src/prefs.js:105
+#: src/prefs.js:116
 msgid "Version"
 msgstr ""
 
@@ -61,30 +61,34 @@ msgstr ""
 msgid "Character only"
 msgstr ""
 
-#: src/resources/ui/preferences.ui:51
+#: src/resources/ui/preferences.ui:49
+msgid "Reverse speed"
+msgstr ""
+
+#: src/resources/ui/preferences.ui:63
 msgid "Reset preferences"
 msgstr ""
 
-#: src/resources/ui/preferences.ui:52
+#: src/resources/ui/preferences.ui:64
 msgid "Reset RunCat preferences to defaults"
 msgstr ""
 
-#: src/resources/ui/preferences.ui:65
+#: src/resources/ui/preferences.ui:77
 msgid "Reset"
 msgstr ""
 
-#: src/resources/ui/preferences.ui:84
+#: src/resources/ui/preferences.ui:96
 msgid "The cat tells you the CPU usage by running speed"
 msgstr ""
 
-#: src/resources/ui/preferences.ui:88
+#: src/resources/ui/preferences.ui:100
 msgid "Visit RunCat's GitHub page"
 msgstr ""
 
-#: src/resources/ui/preferences.ui:98
+#: src/resources/ui/preferences.ui:110
 msgid "Visit Homepage"
 msgstr ""
 
-#: src/resources/ui/preferences.ui:102
+#: src/resources/ui/preferences.ui:114
 msgid "About RunCat"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-runcat-extension 20\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-04 10:43+0300\n"
+"POT-Creation-Date: 2024-01-12 13:59+0100\n"
 "PO-Revision-Date: 2022-09-30 19:16+0300\n"
 "Last-Translator: Sergei Kolesnikov <sergei@kolesnikov.se>\n"
 "Language-Team: Russian\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: src/indicator.js:161
+#: src/indicator.js:170
 msgid "Open System Monitor"
 msgstr "Открыть Системный монитор"
 
-#: src/indicator.js:165
+#: src/indicator.js:174
 msgid "Settings"
 msgstr "Настройки"
 
@@ -30,7 +30,7 @@ msgstr "Настройки"
 msgid "RunCat Settings"
 msgstr "Настройки RunCat"
 
-#: src/prefs.js:105
+#: src/prefs.js:116
 msgid "Version"
 msgstr "Версия"
 
@@ -62,32 +62,36 @@ msgstr "Только проценты"
 msgid "Character only"
 msgstr "Только персонаж"
 
-#: src/resources/ui/preferences.ui:51
+#: src/resources/ui/preferences.ui:49
+msgid "Reverse speed"
+msgstr "Oбратная скорость"
+
+#: src/resources/ui/preferences.ui:63
 msgid "Reset preferences"
 msgstr "Сбросить настройки"
 
-#: src/resources/ui/preferences.ui:52
+#: src/resources/ui/preferences.ui:64
 msgid "Reset RunCat preferences to defaults"
 msgstr "Сбросить настройки RunCat к значениям по умолчанию"
 
-#: src/resources/ui/preferences.ui:65
+#: src/resources/ui/preferences.ui:77
 msgid "Reset"
 msgstr "Сбросить"
 
-#: src/resources/ui/preferences.ui:84
+#: src/resources/ui/preferences.ui:96
 msgid "The cat tells you the CPU usage by running speed"
 msgstr ""
 "Котик, который показывает загрузку\n"
 " процессора скоростью бега"
 
-#: src/resources/ui/preferences.ui:88
+#: src/resources/ui/preferences.ui:100
 msgid "Visit RunCat's GitHub page"
 msgstr "Посетить страницу RunCat на GitHub"
 
-#: src/resources/ui/preferences.ui:98
+#: src/resources/ui/preferences.ui:110
 msgid "Visit Homepage"
 msgstr "Открыть домашнюю страницу"
 
-#: src/resources/ui/preferences.ui:102
+#: src/resources/ui/preferences.ui:114
 msgid "About RunCat"
 msgstr "О RunCat"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-runcat-extension 20\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-12 13:59+0100\n"
+"POT-Creation-Date: 2024-01-15 10:39+0100\n"
 "PO-Revision-Date: 2022-09-30 19:16+0300\n"
 "Last-Translator: Sergei Kolesnikov <sergei@kolesnikov.se>\n"
 "Language-Team: Russian\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: src/indicator.js:170
+#: src/indicator.js:169
 msgid "Open System Monitor"
 msgstr "Открыть Системный монитор"
 
-#: src/indicator.js:174
+#: src/indicator.js:173
 msgid "Settings"
 msgstr "Настройки"
 
@@ -30,7 +30,7 @@ msgstr "Настройки"
 msgid "RunCat Settings"
 msgstr "Настройки RunCat"
 
-#: src/prefs.js:116
+#: src/prefs.js:126
 msgid "Version"
 msgstr "Версия"
 
@@ -63,8 +63,8 @@ msgid "Character only"
 msgstr "Только персонаж"
 
 #: src/resources/ui/preferences.ui:49
-msgid "Reverse speed"
-msgstr "Oбратная скорость"
+msgid "Invert running speed"
+msgstr "Инвертировать скорость"
 
 #: src/resources/ui/preferences.ui:63
 msgid "Reset preferences"
@@ -95,3 +95,6 @@ msgstr "Открыть домашнюю страницу"
 #: src/resources/ui/preferences.ui:114
 msgid "About RunCat"
 msgstr "О RunCat"
+
+#~ msgid "Reverse speed"
+#~ msgstr "Oбратная скорость"

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ export const displayingItems = {
 export const gioSettingsKeys = {
 	IDLE_THRESHOLD: 'idle-threshold',
 	DISPLAYING_ITEMS: 'displaying-items',
+	REVERSE_SPEED: 'reverse-speed',
 }
 
 export const SYSTEM_MONITOR_COMMAND = 'gnome-system-monitor -r'

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,7 +14,7 @@ export const displayingItems = {
 export const gioSettingsKeys = {
 	IDLE_THRESHOLD: 'idle-threshold',
 	DISPLAYING_ITEMS: 'displaying-items',
-	REVERSE_SPEED: 'reverse-speed',
+	INVERT_RUNNING_SPEED: 'invert-running-speed',
 }
 
 export const SYSTEM_MONITOR_COMMAND = 'gnome-system-monitor -r'

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -69,6 +69,14 @@ export default class RunCatPreferences extends ExtensionPreferences {
 			'value',
 			Gio.SettingsBindFlags.DEFAULT,
 		)
+		
+		// Reverse Speed
+		this.#settings.bind(
+			gioSettingsKeys.REVERSE_SPEED,
+			this.#builder.get_object(gioSettingsKeys.REVERSE_SPEED),
+			'active',
+			Gio.SettingsBindFlags.DEFAULT
+		)
 
 		// Displaying Items
 		const combo = /** @type {Adw.ComboRow} */ (this.#builder.get_object(gioSettingsKeys.DISPLAYING_ITEMS))
@@ -82,6 +90,9 @@ export default class RunCatPreferences extends ExtensionPreferences {
 		this.#builder.get_object('reset').connect('clicked', () => {
 			// Idle Threshold
 			this.#settings.reset(gioSettingsKeys.IDLE_THRESHOLD)
+
+			// Reverse Speed
+			this.#settings.reset(gioSettingsKeys.REVERSE_SPEED)
 
 			// Displaying Items
 			this.#settings.reset(gioSettingsKeys.DISPLAYING_ITEMS)

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -69,13 +69,13 @@ export default class RunCatPreferences extends ExtensionPreferences {
 			'value',
 			Gio.SettingsBindFlags.DEFAULT,
 		)
-		
-		// Reverse Speed
+
+		// Invert Running Speed
 		this.#settings.bind(
-			gioSettingsKeys.REVERSE_SPEED,
-			this.#builder.get_object(gioSettingsKeys.REVERSE_SPEED),
+			gioSettingsKeys.INVERT_RUNNING_SPEED,
+			this.#builder.get_object(gioSettingsKeys.INVERT_RUNNING_SPEED),
 			'active',
-			Gio.SettingsBindFlags.DEFAULT
+			Gio.SettingsBindFlags.DEFAULT,
 		)
 
 		// Displaying Items
@@ -91,8 +91,8 @@ export default class RunCatPreferences extends ExtensionPreferences {
 			// Idle Threshold
 			this.#settings.reset(gioSettingsKeys.IDLE_THRESHOLD)
 
-			// Reverse Speed
-			this.#settings.reset(gioSettingsKeys.REVERSE_SPEED)
+			// Invert Running Speed
+			this.#settings.reset(gioSettingsKeys.INVERT_RUNNING_SPEED)
 
 			// Displaying Items
 			this.#settings.reset(gioSettingsKeys.DISPLAYING_ITEMS)

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -78,6 +78,11 @@ export default class RunCatPreferences extends ExtensionPreferences {
 			Gio.SettingsBindFlags.DEFAULT,
 		)
 
+		this.#builder.get_object(gioSettingsKeys.INVERT_RUNNING_SPEED).connect('notify::active', () => {
+			this.#lockIdleThreshold()
+		})
+		this.#lockIdleThreshold()
+
 		// Displaying Items
 		const combo = /** @type {Adw.ComboRow} */ (this.#builder.get_object(gioSettingsKeys.DISPLAYING_ITEMS))
 		// `Gio.Settings.bind_with_mapping` is missing in GJS: https://gitlab.gnome.org/GNOME/gjs/-/issues/397
@@ -98,6 +103,11 @@ export default class RunCatPreferences extends ExtensionPreferences {
 			this.#settings.reset(gioSettingsKeys.DISPLAYING_ITEMS)
 			combo.set_selected(this.#settings.get_enum(gioSettingsKeys.DISPLAYING_ITEMS))
 		})
+	}
+
+	#lockIdleThreshold() {
+		const isLocked = this.#builder.get_object(gioSettingsKeys.INVERT_RUNNING_SPEED).get_active()
+		this.#builder.get_object('idle-threshold-scale').set_sensitive(!isLocked)
 	}
 
 	#setupMenu() {

--- a/src/resources/ui/preferences.ui
+++ b/src/resources/ui/preferences.ui
@@ -46,10 +46,10 @@
 
                 <child>
                     <object class="AdwActionRow">
-                        <property name="title" translatable="yes">Reverse speed</property>
+                        <property name="title" translatable="yes">Invert running speed</property>
 
                         <child>
-                            <object class="GtkSwitch" id="reverse-speed">
+                            <object class="GtkSwitch" id="invert-running-speed">
                                 <property name="valign">center</property>
                             </object>
                         </child>

--- a/src/resources/ui/preferences.ui
+++ b/src/resources/ui/preferences.ui
@@ -43,6 +43,18 @@
                         </property>
                     </object>
                 </child>
+
+                <child>
+                    <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Reverse speed</property>
+
+                        <child>
+                            <object class="GtkSwitch" id="reverse-speed">
+                                <property name="valign">center</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
             </object>
         </child>
 

--- a/src/schemas/org.gnome.shell.extensions.runcat.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.runcat.gschema.xml
@@ -7,8 +7,8 @@
 	</enum>
 
 	<schema
-			id="org.gnome.shell.extensions.runcat"
-			path="/org/gnome/shell/extensions/runcat/"
+		id="org.gnome.shell.extensions.runcat"
+		path="/org/gnome/shell/extensions/runcat/"
 	>
 
 		<key type="i" name="idle-threshold">
@@ -20,6 +20,12 @@
 		<key name="displaying-items" enum="org.gnome.shell.extensions.runcat.DisplayingItems">
 			<default>'character-only'</default>
 			<summary>Displaying items</summary>
+			<description/>
+		</key>
+
+		<key name="reverse-speed" type="b">
+			<default>false</default>
+			<summary>Reverse speed</summary>
 			<description/>
 		</key>
 	</schema>

--- a/src/schemas/org.gnome.shell.extensions.runcat.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.runcat.gschema.xml
@@ -23,9 +23,9 @@
 			<description/>
 		</key>
 
-		<key name="reverse-speed" type="b">
+		<key name="invert-running-speed" type="b">
 			<default>false</default>
-			<summary>Reverse speed</summary>
+			<summary>Invert running speed</summary>
 			<description/>
 		</key>
 	</schema>


### PR DESCRIPTION
Hey Sergei,
After show this awesome extension to a friend, who is a mac user, he installed the mac version of this tool.

Their where some settings, customizing the cat. (changing sprites, other stats like gpu use, etc.) 
One setting i found really useful, was having the cat sprinting most of the time and running "laggy" when the cpu usage was higher.
Not that is make sense, but it looks fun.

I added a setting and reverse the animation timeout.

New switch in settings:
![image](https://github.com/win0err/gnome-runcat/assets/72307968/4607330c-5218-4cf7-9216-ac15c1861ace)
