### PR TITLE
Mark compatible with GNOME Shell 47

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,5 +6,5 @@
 	"settings-schema": "org.gnome.shell.extensions.runcat",
 	"shell-version": ["45", "46", "47"],
 	"url": "https://github.com/win0err/gnome-runcat",
-	"version": 27
+	"version": 28
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -4,7 +4,7 @@
 	"uuid": "runcat@kolesnikov.se",
 	"gettext-domain": "runcat@kolesnikov.se",
 	"settings-schema": "org.gnome.shell.extensions.runcat",
-	"shell-version": ["45", "46"],
+	"shell-version": ["45", "46", "47"],
 	"url": "https://github.com/win0err/gnome-runcat",
 	"version": 27
 }


### PR DESCRIPTION
GNOME 47 is scheduled for release on Wednesday.

I did a very simple smoketest with this change on Debian with gnome-shell 47.rc

See also https://gjs.guide/extensions/upgrading/gnome-shell-47.html