### PR TITLE
Mark compatible with GNOME Shell 48

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -4,7 +4,7 @@
 	"uuid": "runcat@kolesnikov.se",
 	"gettext-domain": "runcat@kolesnikov.se",
 	"settings-schema": "org.gnome.shell.extensions.runcat",
-	"shell-version": ["45", "46", "47", "48"],
+	"shell-version": ["46", "47", "48"],
 	"url": "https://github.com/win0err/gnome-runcat",
-	"version": 28
+	"version": 29
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -4,7 +4,7 @@
 	"uuid": "runcat@kolesnikov.se",
 	"gettext-domain": "runcat@kolesnikov.se",
 	"settings-schema": "org.gnome.shell.extensions.runcat",
-	"shell-version": ["45", "46", "47"],
+	"shell-version": ["45", "46", "47", "48"],
 	"url": "https://github.com/win0err/gnome-runcat",
 	"version": 28
 }


### PR DESCRIPTION
I did a quick test with GNOME Shell 48 Beta from Debian Experimental (GNOME Shell 48 Beta is also available in Ubuntu 25.04) and things appeared to work ok.

See https://gjs.guide/extensions/upgrading/gnome-shell-48.html